### PR TITLE
Fixed error with checking win in column

### DIFF
--- a/BIT504_AT_Task2/src/Board.java
+++ b/BIT504_AT_Task2/src/Board.java
@@ -44,7 +44,7 @@ public class Board {
 			return true; 
 		
 		 //Check if the player has 3 in the playerCol.
-		if (cells[playerRow][0].content == thePlayer && cells[playerRow][1].content == thePlayer && cells[playerRow][2].content == thePlayer) 
+		if (cells[0][playerCol].content == thePlayer && cells[1][playerCol].content == thePlayer && cells[2][playerCol].content == thePlayer) 
 			return true;
 						
 		 // 3-in-the-diagonal


### PR DESCRIPTION
When tested, column wins didn't work and game kept playing until draw or row win. I had playerRow instead of playerCol.